### PR TITLE
Update png dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/PistonDevelopers/resize.git"
 documentation = "http://docs.piston.rs/resize/resize/"
 
 [dev-dependencies]
-png = "0.3"
+png = "0.6"


### PR DESCRIPTION
The old png crate doesn't compile with the current Rust nightly