### PR TITLE
16-bit pixel format support

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,7 @@ extern crate png;
 
 use std::fs::File;
 use std::path::PathBuf;
-use resize::Pixel::Gray8;
+use resize::Pixel::{Gray8, Gray16};
 use resize::Type::Triangle;
 
 fn get_image() -> (png::OutputInfo, Vec<u8>) {
@@ -40,6 +40,22 @@ fn precomputed_small(b: &mut Bencher) {
     let mut dst = vec![0;w2*h2];
 
     let mut r = resize::new(w1, h1, w2, h2, Gray8, Triangle);
+
+    b.iter(|| r.resize(&src, &mut dst));
+}
+
+#[bench]
+fn precomputed_small_16bit(b: &mut Bencher) {
+    let (info, src) = get_image();
+    let (w1, h1) = (info.width as usize, info.height as usize);
+    let (w2, h2) = (100,100);
+    let mut dst = vec![0u16;w2*h2];
+    let src: Vec<_> = src.into_iter().map(|px|{
+        let px = px as u16;
+        (px << 8) | px
+    }).collect();
+
+    let mut r = resize::new(w1, h1, w2, h2, Gray16, Triangle);
 
     b.iter(|| r.resize(&src, &mut dst));
 }


### PR DESCRIPTION
It builds on the previous two PRs. Adds support for 16-bit-per-channel formats.

The original design assumed `[u8]` would be used for everything, but I've kept `[u8]` for 8-bit formats, and switched to `[u16]` for 16-bit ones. This simplifies the code, since all 16-bit reads, offsets and alignment issues are transparently handled by Rust.

