### PR TITLE
Bump png to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/PistonDevelopers/resize.git"
 documentation = "http://docs.piston.rs/resize/resize/"
 
 [dev-dependencies]
-png = "0.6"
+png = "0.14"


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Tested in Fedora Rawhide
https://copr.fedorainfracloud.org/coprs/eclipseo/rav1e/package/rust-resize/