### PR TITLE
Completely remove use of falliable_collections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rust-version = "1.57"
 png = "0.17.7"
 
 [dependencies]
-fallible_collections = { version = "0.4.7", features = ["rust_1_57"] }
 rgb = "0.8.36"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,13 +444,6 @@ pub enum Error {
 
 impl std::error::Error for Error {}
 
-impl From<fallible_collections::TryReserveError> for Error {
-    #[inline(always)]
-    fn from(_: fallible_collections::TryReserveError) -> Self {
-        Self::OutOfMemory
-    }
-}
-
 impl From<std::collections::TryReserveError> for Error {
     #[inline(always)]
     fn from(_: std::collections::TryReserveError) -> Self {


### PR DESCRIPTION
2afa818 removed the use of `falliable_collections`. This PR removes the remaining bits.