### PR TITLE
Add B-spline and Gaussian filters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ fn cubic_bc(b: f32, c: f32, x: f32) -> f32 {
 }
 
 // Taken from
-//https://github.com/image-rs/image/blob/81b3fe66fba04b8b60ba79b3641826df22fca67e/src/imageops/sample.rs#L181
+// https://github.com/image-rs/image/blob/81b3fe66fba04b8b60ba79b3641826df22fca67e/src/imageops/sample.rs#L181
 /// The Gaussian Function.
 /// ```r``` is the standard deviation.
 #[inline(always)]


### PR DESCRIPTION
Hi! I needed B-spline and Gaussian for another project and implemented them myself there. Since others might also find these filters useful, I wanted to make a PR to add them to the project. I might add more in the future too, but no promises.

Changes:
- Add B-spline cubic interpolation. Coefficients come from [this Wikipedia article](https://en.wikipedia.org/w/index.php?title=Mitchell%E2%80%93Netravali_filters&oldid=1167023332#Implementations).
- Add Gaussian filter. I basically just copied the implementation from the `image` crate ([here ](https://github.com/image-rs/image/blob/81b3fe66fba04b8b60ba79b3641826df22fca67e/src/imageops/sample.rs#L181-L183)and [here](https://github.com/image-rs/image/blob/81b3fe66fba04b8b60ba79b3641826df22fca67e/src/imageops/sample.rs#L928-L931)).

Since the `Type` enum is not `#[non_exhaustive]`, this is a breaking change.

---

Related to #12.